### PR TITLE
Fixed issue

### DIFF
--- a/server/cron_job/methods.js
+++ b/server/cron_job/methods.js
@@ -31,7 +31,7 @@ hangoutReminder = function() {
           Hangouts.update({_id: hangout._id},
                           {$set: { day_reminder_sent: true}});
 
-      }  else if (time_diff >= 1 && time_diff <= 2 && hangout.hourly_reminder_sent == false) { // let's alert on Slack channel and email
+      }  else if (time_diff >= 1 && time_diff < 2 && hangout.hourly_reminder_sent == false) { // let's alert on Slack channel and email
           console.log("found a hangout for a 2 hour slack reminder alert");
 
           // send slack alert to default channel!


### PR DESCRIPTION
Fixes #438.

The `time_diff` is calculated using `parseInt` which will chop off any decimal point 
Ex. `parseInt(2.59) // #=> 2`

The if statement was originally checking if the `time_diff <= 2` which in turn will trigger for something that is 2 hours and any number of minutes, so a very simple fix was to change it to `time_diff < 2`
