### PR TITLE
Changed "Browse" link in top nav to "Browse Hangouts" Issue 437 

### DIFF
--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -17,7 +17,7 @@
         <ul class="nav navbar-nav navbar-right">
           <li><a href="{{pathFor 'about'}}">{{_ "about"}} <span class="sr-only">(current)</span></a></li>
           <li><a href="{{pathFor 'faq'}}">{{_ "faq"}}</a></li>
-          <li><a href="{{pathFor 'browse'}}">{{_ "browse"}} <span class="sr-only">(current)</span></a></li>
+          <li><a href="{{pathFor 'browse'}}">{{_ "Hangouts"}} <span class="sr-only">(current)</span></a></li>
           {{#unless isInRole 'admin'}}
              <li><a href="https://codebuddies.slack.com/messages/general" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i> </a></li>
            {{/unless}}

--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -17,7 +17,7 @@
         <ul class="nav navbar-nav navbar-right">
           <li><a href="{{pathFor 'about'}}">{{_ "about"}} <span class="sr-only">(current)</span></a></li>
           <li><a href="{{pathFor 'faq'}}">{{_ "faq"}}</a></li>
-          <li><a href="{{pathFor 'browse'}}">{{_ "Hangouts"}} <span class="sr-only">(current)</span></a></li>
+          {{#unless currentUser}}<li><a href="{{pathFor 'browse_hangouts'}}">{{_ "Hangouts"}} <span class="sr-only">(current)</span></a></li>{{/unless}}
           {{#unless isInRole 'admin'}}
              <li><a href="https://codebuddies.slack.com/messages/general" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i> </a></li>
            {{/unless}}

--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -17,7 +17,7 @@
         <ul class="nav navbar-nav navbar-right">
           <li><a href="{{pathFor 'about'}}">{{_ "about"}} <span class="sr-only">(current)</span></a></li>
           <li><a href="{{pathFor 'faq'}}">{{_ "faq"}}</a></li>
-          {{#unless currentUser}}<li><a href="{{pathFor 'browse_hangouts'}}">{{_ "Hangouts"}} <span class="sr-only">(current)</span></a></li>{{/unless}}
+          {{#unless currentUser}}<li><a href="{{pathFor 'browse_hangouts'}}">{{_ "browse_hangouts"}} <span class="sr-only">(current)</span></a></li>{{/unless}}
           {{#unless isInRole 'admin'}}
              <li><a href="https://codebuddies.slack.com/messages/general" target="_blank"><i class="fa fa-slack" aria-hidden="true"></i> </a></li>
            {{/unless}}

--- a/contributing.md
+++ b/contributing.md
@@ -28,7 +28,7 @@
 
 # The More Detailed Steps on Contributing:
 1. Say hello on the [#codebuddies-meta](https://codebuddies.slack.com/messages/codebuddies-meta/) channel in the Slack. Feel free to ask questions here, or to ask for someone to review your pull request. (If you don't have an account with codebuddies.slack.com, please visit [codebuddies.org](http://codebuddies.org) to sign up.)
-2. Install Meteor! On mac, you should use this command: `curl https://install.meteor.com/ | sed 's/1.3/1.3.2.4/' | sh` On Windows, you should run the official installer [here](https://www.meteor.com/install).
+2. Install Meteor! On mac, you should use this command: `curl "https://install.meteor.com/?release=1.3.2.4" | sh`. On Windows, you should run the official installer [here](https://www.meteor.com/install).
 3. Please star this repository! We need to reach 100 stars so that we can apply to the [Open Collective](https://opencollective.com/opensource/apply).
   [Edit - We're already there! But still star this repo, so others can hear about what we're doing!]
 4. Fork this repository! Once you have a copy of this repo on your own account, clone this repo to your computer by typing in something like:
@@ -43,7 +43,6 @@
   * `git fetch upstream`
   * `git checkout master`
   * `git merge upstream/master`
-6. Run `meteor update --release 1.3.2.4` while you are inside your `codebuddies` folder.
 6. Type `meteor npm install`, and then `meteor --settings settings-development.json` in your terminal to start up the app in your browser ([http://localhost:3000](http://localhost:3000)).
   * (`meteor npm run meteor:dev` can also run the app, but will likely [use up your CPU](https://github.com/meteor/meteor/issues/4314).)
   * Also note: if you see an error in your terminal asking you to `meteor npm install --save faker`, please run that command!

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -113,5 +113,5 @@
 
   //visitor
   "sign_in_to_continue" : "Please sign in to continue.",
-  "browse" : "Browse"
+  "browse" : "Hangouts"
 }

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -113,5 +113,5 @@
 
   //visitor
   "sign_in_to_continue" : "Please sign in to continue.",
-  "browse" : "Hangouts"
+  "browse_hangouts" : "Hangouts"
 }

--- a/i18n/es.i18n.json
+++ b/i18n/es.i18n.json
@@ -113,5 +113,5 @@
 
   //visitor
   "sign_in_to_continue" : "Por favor regístrate para continuar",
-  "browse" : "Navegar"
+  "browse_hangouts" : "Navegar"
 }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -16,8 +16,8 @@ FlowRouter.route('/', {
   }
 });
 
-FlowRouter.route('/browse', {
-  name: 'browse',
+FlowRouter.route('/browse_hangouts', {
+  name: 'browse_hangouts',
   action: function(params, queryParams) {
     BlazeLayout.render('layout', { top: 'header', main: 'hasBlocked', targetTemplate: 'hangoutBoard', footer: 'footer' });
   }


### PR DESCRIPTION
Fixes #437 .

Changed the navbar at the top of the Codebuddies home page, replacing the word "Browse" with "Hangouts".  Also, updating the path to this section, changing it from "browse" to "browse_hangouts".  

Also, since users who are logged in will already see all hangouts, "Hangouts" will not appear in the navbar for users who are already logged in. 