### PR TITLE
Fix 454: Show "most recent" instead of "oldest" first on Profile

### DIFF
--- a/client/templates/profile/profile-hangouts-joined/profile-hangouts-joined.js
+++ b/client/templates/profile/profile-hangouts-joined/profile-hangouts-joined.js
@@ -19,7 +19,7 @@ Template.hangoutsJoined.onRendered(function() {
 
     instance.loadHangouts = function() {
       var userId = FlowRouter.getParam('userId');
-      var arr = Hangouts.find().fetch();
+      var arr = Hangouts.find().fetch().reverse();
       var userHangouts = _.filter(arr, function(elem) { return elem.users.includes(userId)});
       return userHangouts;
     }


### PR DESCRIPTION
Fixes #454 .

Added a `.reverse()` after fetching the hangouts, which sorts them with most recent first.