### PR TITLE
changed font color, weight, and top margin of hangout post titles

### DIFF
--- a/client/css/_hangout_card.scss
+++ b/client/css/_hangout_card.scss
@@ -12,12 +12,12 @@
     color: $secondary-grey;
   }
   .hangout-topic {
-    margin-top: 0px;
+    margin-top: 10px;
     margin-bottom: 5px;
-    @include font-face(400, 17px, normal, $cta-blue);
-    text-align: justify;
+    @include font-face(bold, 17px, normal, black);
+    text-align: left;
     &.completed {
-      color: $secondary-grey;
+      color: #8e8e8e;
     }
   }
   .hangout-date {

--- a/client/css/_hangout_card.scss
+++ b/client/css/_hangout_card.scss
@@ -12,9 +12,9 @@
     color: $secondary-grey;
   }
   .hangout-topic {
-    margin-top: 10px;
+    margin-top: 3px;
     margin-bottom: 5px;
-    @include font-face(bold, 17px, normal, $black);
+    @include font-face(600, 17px, normal, $black);
     text-align: left;
     &.completed {
       color: $secondary-grey;

--- a/client/css/_hangout_card.scss
+++ b/client/css/_hangout_card.scss
@@ -14,10 +14,10 @@
   .hangout-topic {
     margin-top: 10px;
     margin-bottom: 5px;
-    @include font-face(bold, 17px, normal, black);
+    @include font-face(bold, 17px, normal, $black);
     text-align: left;
     &.completed {
-      color: #8e8e8e;
+      color: $secondary-grey;
     }
   }
   .hangout-date {


### PR DESCRIPTION
Fixes #508 

Resolves the feature request that requests the post title to be black, text-aligned: left, and bolded. I noticed, that when bolded, the text sometimes was displayed incorrectly. I increased the top margin by 10px, to counteract the bug.