### PR TITLE
Fix for issue 522: add external link to Jitsi hangout onto the hangout page so…

### DIFF
--- a/client/templates/hangout/hangout-frame.html
+++ b/client/templates/hangout/hangout-frame.html
@@ -6,7 +6,8 @@
   <img src="/images/click_to_load_hangout2.jpg" width="50%" class="load-hangout load-hangout-screenshot"/>
 </div>
 
- <div id="hangout-container"></div> 
+  <p class="align-center">If you're seeing a blank screen, <a href="https://meet.jit.si/cb{{_id}}" target="_blank">join here.</a></p>
+  <div id="hangout-container"></div> 
   <span id="post_id" class="hide">{{_id}}</span>
 
 </template>


### PR DESCRIPTION
… participants can get to it easily if Jitsi shows a blank grey screen on click.

Fixes #522 
![screen shot 2017-06-21 at 10 26 05 pm](https://user-images.githubusercontent.com/4512699/27418547-a7c986e8-56d0-11e7-9ef9-6af0345499e9.jpg)

