### PR TITLE
Change URLs to the correct one

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,4 @@ Describe the big picture of your changes here to communicate to the maintainers 
 
 Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
 
-Always follow the [contribution guidelines](https://github.com/codebuddiesdotorg/cb-v2-scratch/blob/master/contributing.md) when submitting a pull request.
+Always follow the [contribution guidelines](https://github.com/codebuddiesdotorg/codebuddies/blob/master/contributing.md) when submitting a pull request.

--- a/client/templates/home/footer.html
+++ b/client/templates/home/footer.html
@@ -21,7 +21,7 @@
             <div class="footer-social">
               <p><strong>CONNECT WITH US</strong></p>
               <span class="footer-icons">
-                  <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch" target="_blank"><i class="fa fa-github"></i></a>
+                  <a href="https://github.com/codebuddiesdotorg/codebuddies" target="_blank"><i class="fa fa-github"></i></a>
                   <a href="https://codebuddies.slack.com" target="_blank"><i class="fa fa-slack"></i></a>
                   <a href="https://twitter.com/codebuddiesmeet" target="_blank"><i class="fa fa-twitter"></i></a>
                   <a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank"><i class="fa fa-facebook"></i></a>

--- a/client/templates/other/about.html
+++ b/client/templates/other/about.html
@@ -52,17 +52,17 @@
   	        </div>
   	        <div class="col-md-6">
 		        	<h3>How we built this</h3>
-  		        	<p> This project is 100% built by volunteers in the community. We created a Google Doc with specs, volunteers stepped up to talk design and create mockups, more volunteers built the foundations of the codebase, and more continually step up to help with our <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch/" target="_blank">Github issues</a>. In addition, volunteers keep our <a href="http://codebuddies.slack.com" target="_blank">Slack chatroom</a> alive, moderating the chat, sharing useful links and discounts, and answering each other's coding-related questions.</p>
+  		        	<p> This project is 100% built by volunteers in the community. We created a Google Doc with specs, volunteers stepped up to talk design and create mockups, more volunteers built the foundations of the codebase, and more continually step up to help with our <a href="https://github.com/codebuddiesdotorg/codebuddies/" target="_blank">Github issues</a>. In addition, volunteers keep our <a href="http://codebuddies.slack.com" target="_blank">Slack chatroom</a> alive, moderating the chat, sharing useful links and discounts, and answering each other's coding-related questions.</p>
 		        </div>
 		     </div>
 				 <div class="row">
 						 <div class="col-md-6">
 		           <h3>Our Pledge</h3>
-  		           <p>In the interest of fostering an open and welcoming environment, we as community members, contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation. <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch/blob/master/CODE_OF_CONDUCT.md" target="_blank">Read our code of conduct.</a></p>
+  		           <p>In the interest of fostering an open and welcoming environment, we as community members, contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation. <a href="https://github.com/codebuddiesdotorg/codebuddies/blob/master/CODE_OF_CONDUCT.md" target="_blank">Read our code of conduct.</a></p>
 	           </div>
 		         <div class="col-md-6">
                <h3>We are open-sourced</h3>
-             		<p>This website is <strong>100%</strong> community-built and open-sourced on Github. Come say hi and <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch/blob/master/contributing.md" target="_blank">contribute to this project</a> if you want to help!
+             		<p>This website is <strong>100%</strong> community-built and open-sourced on Github. Come say hi and <a href="https://github.com/codebuddiesdotorg/codebuddies/blob/master/contributing.md" target="_blank">contribute to this project</a> if you want to help!
              		</p>
 		           <h3>We are fully transparent</h3>
       					<p>This project operates in full transparency as a member of the Open Collective. Please help support our monthly server costsby becoming a <a href="http://opencollective.com/codebuddies" target="_blank">sponsor or backer</a>. You can help keep this project alive!</p>

--- a/client/templates/other/faq.html
+++ b/client/templates/other/faq.html
@@ -20,7 +20,7 @@
                 <ul>
                   <li><a href="http://codebuddies.slack.com" target="_blank">Slack</a> (<a href="http://codebuddiesmeet.herokuapp.com" target="_blank" >Get your invite</a>)</li>
                   <li><a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank">Facebook Group</a></li>
-                  <li><a href="https://github.com/codebuddiesdotorg/cb-v2-scratch">Github</a> - <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch/blob/master/contributing.md" target="_blank">Contributing.md</a>, <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch/pulls" target="_blank">Pull Requests</a>
+                  <li><a href="https://github.com/codebuddiesdotorg/codebuddies">Github</a> - <a href="https://github.com/codebuddiesdotorg/codebuddies/blob/master/contributing.md" target="_blank">Contributing.md</a>, <a href="https://github.com/codebuddiesdotorg/codebuddies/pulls" target="_blank">Pull Requests</a>
                   </li>
                   <li><a href="http://twitter.com/codebuddiesmeet" target="_blank">@codebuddiesmeet</a></li>
                   <li><a href="http://opencollective.com/codebuddies">Open Collective</a></li>
@@ -46,7 +46,7 @@
               <h3>How is this project funded?</h3>
                 <p> This project operates in full transparency as a member of the <a href="http://opencollective.com/codebuddies" target="_blank">Open Collective</a>. Please help support our monthly server costs by becoming a <a href="http://opencollective.com/codebuddies" target="_blank">sponsor or backer</a>. You can help keep this project alive!</p>
              <h3>Do you have a community code of conduct?</h3>
-                <p>Yes. See <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch/blob/master/CODE_OF_CONDUCT.md"> this.</a></p>
+                <p>Yes. See <a href="https://github.com/codebuddiesdotorg/codebuddies/blob/master/CODE_OF_CONDUCT.md"> this.</a></p>
               <h3>Why did you all work together to build this site?</h3>
                 <p>Our community spends a lot of time helping each other on Slack, but it's hard to schedule study times in advance in a chatroom, and it's also hard to know who else is online possibly working on the same thing at the same time. This website solves those issues.</p>
            </div>

--- a/client/templates/other/sponsor-us.html
+++ b/client/templates/other/sponsor-us.html
@@ -4,7 +4,7 @@
 			<div class="col-md-12 text-center">
 				<div class="col-md-6 col-md-offset-3">
 					<h2>Help us keep this project alive!</h2>
-					<p id="explain">This website is 100% community-built (<a href="https://github.com/codebuddiesdotorg/cb-v2-scratch" target="_blank"><i class="fa fa-github"></i></a>) and relies on sponsors. Our  hosting costs are $30/month. By choosing to be the sponsor of a month, you will receive our unlimited gratitude and a spot in the Hall of Fame below.</p>
+					<p id="explain">This website is 100% community-built (<a href="https://github.com/codebuddiesdotorg/codebuddies" target="_blank"><i class="fa fa-github"></i></a>) and relies on sponsors. Our  hosting costs are $30/month. By choosing to be the sponsor of a month, you will receive our unlimited gratitude and a spot in the Hall of Fame below.</p>
 				</div>
 			</div>
 		</div>

--- a/client/templates/other/terms-of-service.html
+++ b/client/templates/other/terms-of-service.html
@@ -30,7 +30,7 @@
           <p>We strongly advise you to read the terms and conditions and privacy policies of any third-party web sites or services that you visit.</p>
 
           <h3>Adherence to our Code of Conduct</h3>
-          <p>As a member of the CodeBuddies community, you agree to adhere to our community <a href="https://github.com/codebuddiesdotorg/cb-v2-scratch/blob/master/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a>.</p>
+          <p>As a member of the CodeBuddies community, you agree to adhere to our community <a href="https://github.com/codebuddiesdotorg/codebuddies/blob/master/CODE_OF_CONDUCT.md" target="_blank">Code of Conduct</a>.</p>
 
 
           <h3>Termination</h3>

--- a/contributing.md
+++ b/contributing.md
@@ -44,7 +44,7 @@ On Windows, you should run the official installer [here](https://www.meteor.com/
   (Replace the URL with your own repository URL path.)
   
 5. Run `cd codebuddies`. Then, set up this repository as an upstream branch using:
-  * `git remote add upstream https://github.com/codebuddiesdotorg/cb-v2-scratch.git`
+  * `git remote add upstream https://github.com/codebuddiesdotorg/codebuddies.git`
 
   Now, whenever you want to sync with the owner repository. Do the following:
   * `git fetch upstream`
@@ -59,7 +59,7 @@ On Windows, you should run the official installer [here](https://www.meteor.com/
   * (`meteor npm run meteor:dev` can also run the app, but will likely [use up your CPU](https://github.com/meteor/meteor/issues/4314).)
   * Also note: if you see an error in your terminal asking you to `meteor npm install --save faker`, please run that command!
 
-8.Look at some of the [open issues](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues) and identify one that sparks your interest.
+8.Look at some of the [open issues](https://github.com/codebuddiesdotorg/codebuddies/issues) and identify one that sparks your interest.
 
 If you want to work on the issue, leave a comment on it saying that you're working on it!
 
@@ -71,7 +71,7 @@ Then, create a new branch by typing `git checkout -b BRANCHNAME`. Replace BRANCH
 12. Submit your Pull Request! See some tips on [how to create the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request).
 13. (Optional) Add yourself as a contributor, if you haven't done so already. Steps are listed [below](#how-do-i-add-myself-as-a-contributor).
 
-If you see a bug in the app or have a feature request, feel free to [create a new issue](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues/new) on the Github repo!
+If you see a bug in the app or have a feature request, feel free to [create a new issue](https://github.com/codebuddiesdotorg/codebuddies/issues/new) on the Github repo!
 
 
 # Common Questions
@@ -89,7 +89,7 @@ If you have any problems getting the app to start, feel free to ask in the #trou
 
   `git checkout -b NAME_OF_NEW_BRANCH`
 
-  So for example, if you wanted to work on issue #29 [github.com/codebuddiesdotorg/cb-v2-scratch/issues/29](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues/29), you should type:
+  So for example, if you wanted to work on issue #29 [github.com/codebuddiesdotorg/codebuddies/issues/29](https://github.com/codebuddiesdotorg/codebuddies/issues/29), you should type:
 
     `git checkout -b fix/issue-29-limit-140-characters`
 
@@ -107,7 +107,7 @@ Now we can make commits to our branch (`git commit -am "commit message"`) and `g
 
 Finally, when you're finished working on the fix or feature in your branch, you'll need to submit a pull request!
 
-Click on the "pull request" button by going to https://github.com/codebuddiesdotorg/cb-v2-scratch/pulls and clicking on "new pull request." Next, select your branch, and submit.
+Click on the "pull request" button by going to https://github.com/codebuddiesdotorg/codebuddies/pulls and clicking on "new pull request." Next, select your branch, and submit.
 
 One of the github maintainers (@linda or someone else) will look over your pull request and accept it after it is reviewed by volunteer contributors. Note that for best practice, the PR [may get "squashed" into one commit](http://softwareengineering.stackexchange.com/questions/263164/why-squash-git-commits-for-pull-requests). If you prefer that the merge not be squashed into one commit, just let us know in the PR! 
 
@@ -177,7 +177,7 @@ When the app is run locally, there are no hangouts seeded by default. Hence to b
 ### How do I add myself as a contributor?
 *Make sure you have recently `git pull` from `master` before continuing.*
 
-Once you've submitted your PR, switch to the branch [`adding-contributor`](https://github.com/codebuddiesdotorg/cb-v2-scratch/tree/adding-contributor). Then, you can add yourself to both the README.md and on our About page. Keeping a separate branch for adding yourself as a contributor will alleviate most merge conflicts.
+Once you've submitted your PR, switch to the branch [`adding-contributor`](https://github.com/codebuddiesdotorg/codebuddies/tree/adding-contributor). Then, you can add yourself to both the README.md and on our About page. Keeping a separate branch for adding yourself as a contributor will alleviate most merge conflicts.
 
 * Switch to contributor's branch
   * `git checkout adding-contributor`

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,13 @@
-![CodeBuddies logo](https://github.com/codebuddiesdotorg/cb-v2-scratch/raw/master/public/images/cb-readme.jpg)
+![CodeBuddies logo](https://github.com/codebuddiesdotorg/codebuddies/raw/master/public/images/cb-readme.jpg)
 
 # CodeBuddies Hangouts Platform v2.0 - from scratch
 
 
 [![slack in](http://codebuddiesmeet.herokuapp.com/badge.svg?style=flat-square)](http://codebuddiesmeet.herokuapp.com/)
-[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/codebuddiesdotorg/cb-v2-scratch/issues)
+[![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/codebuddiesdotorg/codebuddies/issues)
 [![first-timers-only](https://img.shields.io/badge/first--timers--only-friendly-blue.svg?style=flat-square)](http://www.firsttimersonly.com/)
-[![Issue Stats](https://img.shields.io/issuestats/i/github/codebuddiesdotorg/cb-v2-scratch.svg?maxAge=2592000&style=flat-square)]()
-[![Issue Stats](https://img.shields.io/issuestats/p/github/codebuddiesdotorg/cb-v2-scratch.svg?maxAge=2592000&style=flat-square)]()
+[![Issue Stats](https://img.shields.io/issuestats/i/github/codebuddiesdotorg/codebuddies.svg?maxAge=2592000&style=flat-square)]()
+[![Issue Stats](https://img.shields.io/issuestats/p/github/codebuddiesdotorg/codebuddies.svg?maxAge=2592000&style=flat-square)]()
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 
 # FAQ


### PR DESCRIPTION
Fixes #539 .

I'm new to open source, so this is my first contribution. 

I went through all of the files and replaced https://github.com/codebuddiesdotorg/cb-v2-scratch with https://github.com/codebuddiesdotorg/codebuddies. I also went through the README.md and replaced /cb-v2-scratch with /codebuddies as well. If this wasn't needed, please let me know and I can go back and change those.
