### PR TITLE
Issue 546 : Open Collective Link

### DIFF
--- a/client/templates/home/footer.html
+++ b/client/templates/home/footer.html
@@ -15,6 +15,7 @@
                 <a href="/about">About Us</a>
                 <a href="/faq">FAQ</a>
                 <a href="https://medium.com/codebuddies" target="_blank">Medium Publication</a>
+                <a href="https://opencollective.com/codebuddies" target="_blank">Open Collective</a>
                 <a href="/privacy">Privacy Policy</a>
             </div>
           </div>


### PR DESCRIPTION
Fixes  : Issue #546 

Added a link to the Open Collective : opencollective.com/codebuddies, below the "Medium Publication" link in the footer.