### PR TITLE
Fix for 579: Give owners and admins the ability to edit the title and tagline of a…

### DIFF
--- a/client/css/_study_groups.scss
+++ b/client/css/_study_groups.scss
@@ -1,7 +1,7 @@
 #study-groups {
   h2 {
     margin: 10px 0px;
-    @include font-face(600, 28px, normal, $black);
+    @include font-face(600, 24px, normal, $black);
   }
   h3 {
     text-transform: uppercase;

--- a/client/templates/study_groups/edit_study_group_info_modal.js
+++ b/client/templates/study_groups/edit_study_group_info_modal.js
@@ -56,7 +56,7 @@ Template.editStudyGroupInfoModal.events({
       }
       if(result){
         template.processing.set( false );
-        Bert.alert( 'info updated' , 'success', 'growl-top-right' );
+        Bert.alert( 'Description updated!' , 'success', 'growl-top-right' );
         Modal.hide()
       }
     });

--- a/client/templates/study_groups/edit_study_group_title_modal.html
+++ b/client/templates/study_groups/edit_study_group_title_modal.html
@@ -1,0 +1,40 @@
+<template name="editStudyGroupTitleModal">
+  <div class="modal fade study-group">
+    <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <form class="updateStudyGroupTitle">
+
+            <div class="modal-header">
+              <button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
+              <h2>{{title}}</h2>
+            </div>
+            <div class="modal-body">
+
+              <div class="form-group">
+                <label  class="control-label">Title</label>
+                <textarea name="sgTitle" class="form-control" id="sgTitle" rows="3" cols="70" placeholder="Title">{{title}}</textarea>
+                <small class="pull-right">{{titleCharCount}}</small>
+              </div>
+
+              <div class="form-group">
+                <label  class="control-label">Tagline</label>
+                <textarea name="sgTagline" class="form-control" id="sgTagline" rows="5" cols="70" placeholder="Tagline">{{tagline}}</textarea>
+                <small class="pull-right">{{taglineCharCount}}</small>
+              </div>
+
+            </div><!--modal body-->
+
+            <div class="modal-footer">
+              {{#unless processing}}
+                <button id="submit" class="btn btn-primary btn-block">Save</button>
+              {{else}}
+                <button type="button" class="btn btn-primary btn-block disabled"><i class="fa fa-refresh fa-spin"></i> {{_ "state_processing"}}</button>
+              {{/unless}}
+            </div>
+
+          </form>
+
+      </div><!--modal content-->
+    </div><!--modal dialog-->
+  </div>
+</template>

--- a/client/templates/study_groups/edit_study_group_title_modal.js
+++ b/client/templates/study_groups/edit_study_group_title_modal.js
@@ -1,0 +1,84 @@
+Template.editStudyGroupTitleModal.onCreated(function () {
+  let instance = this;
+  instance.processing = new ReactiveVar(false);
+  instance.titleCharCount = new ReactiveVar(70);
+  instance.taglineCharCount = new ReactiveVar(60);
+});
+
+Template.editStudyGroupTitleModal.onRendered(function () {
+  let instance = this;
+  let titleCharCount =  $("#sgTitle").val().length || 0;
+  instance.titleCharCount.set(70 - titleCharCount)
+
+  let taglineCharCount =  $("#sgTagline").val().length || 0;
+  instance.taglineCharCount.set(60 - taglineCharCount)
+});
+
+Template.editStudyGroupTitleModal.helpers({
+  processing() {
+    return  Template.instance().processing.get();
+  },
+  titleCharCount() {
+    return  Template.instance().titleCharCount.get();
+  },
+  taglineCharCount() {
+    return  Template.instance().taglineCharCount.get();
+  }
+});
+
+Template.editStudyGroupTitleModal.events({
+  "keyup #sgTitle": function(event, template){
+    let titleCharCount =  $("#sgTitle").val().length || 0;
+    template.titleCharCount.set(70 - titleCharCount)
+  },
+  "keyup #sgTagline": function(event, template){
+    let taglineCharCount =  $("#sgTagline").val().length || 0;
+    template.taglineCharCount.set(60 - taglineCharCount)
+  },
+  "submit .updateStudyGroupTitle": function(event, template){
+    event.preventDefault();
+
+    $('.form-control').css({ "border": '1px solid #cccccc'});
+
+    if ($.trim(template.find("#sgTitle").value) == '') {
+      $('#sgTitle').css({ 'border': '#FF0000 1px solid'});
+      return Bert.alert( 'Your title cannot be empty.', 'warning', 'growl-top-right' );
+    }
+    if ($.trim(template.find("#sgTagline").value) == '') {
+      $('#sgTitle').css({ 'border': '#FF0000 1px solid'});
+      return Bert.alert( 'Your tagline cannot be empty.', 'warning', 'growl-top-right' );
+    }
+    if ( $("#sgTitle").val().length > 70) {
+      $('#sgTitle').css({ 'border': '#FF0000 1px solid'});
+      return Bert.alert( 'Please shorten your title.', 'warning', 'growl-top-right' );
+    }
+    if ( $("#sgTagline").val().length > 60) {
+      $('#sgTagline').css({ 'border': '#FF0000 1px solid'});
+      return Bert.alert( 'Please shorten your tagline.', 'warning', 'growl-top-right' );
+    }
+
+
+    const data = {
+      id: this._id,
+      title: $.trim(template.find("#sgTitle").value),
+      tagline: $.trim(template.find("#sgTagline").value)
+    }
+
+
+    // console.log(data);
+    template.processing.set( true );
+
+    Meteor.call("updateStudyGroupTitle", data, function(error, result){
+      if(error){
+        template.processing.set( false );
+        Bert.alert( error.reason , 'danger', 'growl-top-right' );
+      }
+      if(result){
+        template.processing.set( false );
+        Bert.alert( 'Title/tagline updated!' , 'success', 'growl-top-right' );
+        Modal.hide()
+      }
+    });
+
+  }
+});

--- a/client/templates/study_groups/single_study_group.html
+++ b/client/templates/study_groups/single_study_group.html
@@ -12,6 +12,7 @@
               <li><a href="{{pathFor 'my study groups'}}">My Study Groups</a></li>
             {{/unless}}
             <li class="active">{{title}}</li>
+
           </ol>
         </div>
 
@@ -34,6 +35,9 @@
             {{/if}}
 
             <h2>{{title}}
+                {{#if isInRole 'owner, admin' _id}}
+                  <div class="btn btn-default pull-right" id="editTitle"><i class="fa fa-pencil-square-o" aria-hidden="true"></i></div>
+                {{/if}}
 
               <h5><i class="fa fa-map-pin" aria-hidden="true"></i> {{tagline}}</h5>
 

--- a/client/templates/study_groups/single_study_group.js
+++ b/client/templates/study_groups/single_study_group.js
@@ -82,4 +82,8 @@ Template.singleStudyGroup.events({
     event.preventDefault();
     return Modal.show('studyGroupMemberDetail', this);
   },
+  "click #editTitle": function(event, template){
+     event.preventDefault();
+     Modal.show('editStudyGroupTitleModal', this);
+  },
 });

--- a/server/study_groups/methods.js
+++ b/server/study_groups/methods.js
@@ -288,6 +288,36 @@ Meteor.methods({
   }
 });
 
+/**
+* update study group title and tagline
+* @function
+* @name updateStudyGroupTitle
+* @param {Object}
+* @return {Boolean} true on success
+*/
+
+
+Meteor.methods({
+  updateStudyGroupTitle(data){
+    check(data,{
+      id: String,
+      title: String,
+      tagline: String
+    })
+
+    const actor = Meteor.user()
+
+    //check if user is owner or admin
+    if (!actor || !Roles.userIsInRole(actor, ['owner','admin'], data.id )) {
+      throw new Meteor.Error(403, "Access denied");
+    }
+
+    StudyGroups.update({_id: data.id}, { $set:{title: data.title, tagline: data.tagline }});
+
+    return true;
+  }
+});
+
 
 /**
 * Archive Studygroup


### PR DESCRIPTION
Fixes #579.

- Owners and admins sees an edit button that allows them to edit the title and tagline of a group
- Titles are limited to 70 characters; taglines are limited to 60 characters. If we want to change these numbers, let's open up a new issue/PR.