### PR TITLE
Check study group name is unique before new study group can create

### DIFF
--- a/server/study_groups/methods.js
+++ b/server/study_groups/methods.js
@@ -20,6 +20,12 @@ Meteor.methods({
        throw new Meteor.Error('StudyGroups.methods.createNewStudyGroup.not-logged-in', 'Must be logged in to create new Study Group.');
      }
 
+     // Check study group name is unique
+     isTitleAlreadyUsed = StudyGroups.find({title: data.title, visibility: true}).count() > 0;
+     if (isTitleAlreadyUsed) {
+       throw new Meteor.Error('StudyGroups.methods.createNewStudyGroup.title-already-used', 'Study group name is already used');
+     }
+
      const user = Meteor.user();
 
      const studyGroup = {

--- a/server/study_groups/methods.js
+++ b/server/study_groups/methods.js
@@ -21,7 +21,8 @@ Meteor.methods({
      }
 
      // Check study group name is unique
-     isTitleAlreadyUsed = StudyGroups.find({title: data.title, visibility: true}).count() > 0;
+     const regex = new RegExp(`^${data.title}$`, 'i');
+     const isTitleAlreadyUsed = StudyGroups.findOne({title: regex, visibility: true});
      if (isTitleAlreadyUsed) {
        throw new Meteor.Error('StudyGroups.methods.createNewStudyGroup.title-already-used', 'Study group name is already used');
      }


### PR DESCRIPTION
Fixes #585 .

I query study_groups collection in MongoDB to perform exact match on title and visibility equals true and return record count. If count is greater than 0, then Meteor throws error. Otherwise, the function follows the same logic to create new study group.

New study group is allowed to create if the name is used for the first time or all study groups with the same name are archived.