### PR TITLE
Scroll page to top of window when it is rendered

### DIFF
--- a/client/templates/other/about.js
+++ b/client/templates/other/about.js
@@ -21,5 +21,11 @@ Template.about.onRendered(function(){
             content: 'This is the popover content. You should be able to mouse over HERE.'
         });
     });
+
+    // Move to the top of the page on render
+    var $window = $(window);
+    if ($window.scrollTop() > 0) {
+      $window.scrollTop(0);
+    }
 	 });
 });

--- a/client/templates/other/faq.js
+++ b/client/templates/other/faq.js
@@ -4,3 +4,14 @@ Template.faq.onCreated(function(){
   DocHead.setTitle(title);
   DocHead.addMeta(metaInfo);  DocHead.setTitle('CodeBuddies | FAQ');
 });
+
+Template.faq.onRendered(function() {
+  $(function() {
+
+    // Move to the top of the page on render
+    var $window = $(window);
+    if ($window.scrollTop() > 0) {
+      $window.scrollTop(0);
+    }
+  });
+});

--- a/client/templates/other/privacy.js
+++ b/client/templates/other/privacy.js
@@ -1,0 +1,10 @@
+Template.privacyPolicy.onRendered(function() {
+  $(function() {
+
+    // Move to the top of the page on render
+    var $window = $(window);
+    if ($window.scrollTop() > 0) {
+      $window.scrollTop(0);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #595.

I add the scroll top logic in OnRendered template method of about faq and private policy pages.
When the page is first rendered,  $(window).scrollTop() function is invoked to obtain the scrollTop value. If the value is greater than 0, scrollTop is set to 0 to force the page to move to (0,0) of the browser window.
