### PR TITLE
Issue 650 - changed 'Organizer' to 'Moderator'

### DIFF
--- a/client/templates/study_groups/all_study_groups.html
+++ b/client/templates/study_groups/all_study_groups.html
@@ -40,7 +40,7 @@
                     <span class="label label-primary pull-right">Admin</span>
                   {{/if}}
                   {{#if isInRole 'moderator' _id}}
-                    <span class="label label-primary pull-right">Organizer</span>
+                    <span class="label label-primary pull-right">Moderator</span>
                   {{/if}}
                   {{#if isInRole 'member' _id}}
                     <span class="label label-primary pull-right">Member</span>

--- a/client/templates/study_groups/all_study_groups_homepage.html
+++ b/client/templates/study_groups/all_study_groups_homepage.html
@@ -19,7 +19,7 @@
                     <span class="label-box label label-primary pull-right">Admin</span>
                   {{/if}}
                   {{#if isInRole 'moderator' _id}}
-                    <span class="label-box label label-primary pull-right">Organizer</span>
+                    <span class="label-box label label-primary pull-right">Moderator</span>
                   {{/if}}
                   {{#if isInRole 'member' _id}}
                     <span class="label-box label label-primary pull-right">Member</span>

--- a/client/templates/study_groups/my_study_groups.html
+++ b/client/templates/study_groups/my_study_groups.html
@@ -27,7 +27,7 @@
                   <span class="label label-primary pull-right">Admin</span>
                 {{/if}}
                 {{#if isInRole 'moderator' _id}}
-                  <span class="label label-primary pull-right">Organizer</span>
+                  <span class="label label-primary pull-right">Moderator</span>
                 {{/if}}
                 {{#if isInRole 'member' _id}}
                   <span class="label label-primary pull-right">Member</span>

--- a/client/templates/study_groups/study_group_search_result.html
+++ b/client/templates/study_groups/study_group_search_result.html
@@ -19,7 +19,7 @@
                   <span class="label label-primary pull-right">Admin</span>
                 {{/if}}
                 {{#if isInRole 'moderator' _id}}
-                  <span class="label label-primary pull-right">Organizer</span>
+                  <span class="label label-primary pull-right">Moderator</span>
                 {{/if}}
                 {{#if isInRole 'member' _id}}
                   <span class="label label-primary pull-right">Member</span>


### PR DESCRIPTION
This fixes #650 .

There were several instances where users with the `Moderator` role were displayed as `Oranizer`s. 