### PR TITLE
Issue 654 navbar reorganization

### DIFF
--- a/client/css/_navbar.scss
+++ b/client/css/_navbar.scss
@@ -33,11 +33,5 @@
       height: 34px;
       margin-top: -4px;
     }
-
-    .dropdown-menu {
-      .fa-li {
-          position: initial;
-      }
-    }
   }
 }

--- a/client/css/_navbar.scss
+++ b/client/css/_navbar.scss
@@ -33,5 +33,11 @@
       height: 34px;
       margin-top: -4px;
     }
+
+    .dropdown-menu {
+      .fa-li {
+          position: initial;
+      }
+    }
   }
 }

--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -59,7 +59,7 @@
           {{! for logged in user}}
           {{else}}
 
-            {{! won''t be visible to cb admin}}
+            {{! won't be visible to cb admin}}
             {{#unless isInRole 'admin' 'CB'}}
               <!-- notification for user-->
               <li><a href="{{pathFor 'user notification'}}"><i class="fa fa-bell" aria-hidden="true"></i> {{#if userNotificationCount}}<small><span class="badge">{{userNotificationCount}}</span></small>{{/if}} </a></li>

--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -23,35 +23,31 @@
                 Community<span class="caret"></span>
               </a>
               <ul class="dropdown-menu fa-ul">
-                 <li><a href="{{pathFor 'about'}}"><i class="fa-li fa fa-users" aria-hidden="true"></i>
+                 <li><a href="{{pathFor 'about'}}"><i class="fa fa-users fa-fw" aria-hidden="true"></i>
                    {{_ "about"}}<span class="sr-only">(current)</span>
                  </a></li>
                  <li role="separator" class="divider"></li>
                  <li><a href="https://codebuddies.slack.com" target="_blank">
-                      <i class="fa-li fa fa-slack" aria-hidden="true"></i>Slack
+                      <i class="fa fa-slack fa-fw" aria-hidden="true"></i>Slack
                     </a></li>
                  <li role="separator" class="divider"></li>
                  <li><a href="https://github.com/codebuddiesdotorg/codebuddies" target="_blank">
-                   <i class="fa-li fa fa-github" aria-hidden="true"></i>Github
+                   <i class="fa fa-github fa-fw" aria-hidden="true"></i>Github
                  </a></li>
                  <li role="separator" class="divider"></li>
                  <li><a href="https://medium.com/codebuddies" target="_blank">
-                   <i class="fa-li fa fa-medium" aria-hidden="true"></i>Blog
+                   <i class="fa fa-medium fa-fw" aria-hidden="true"></i>Blog
                  </a></li>
                  <li role="separator" class="divider"></li>
                  <li><a href="{{pathFor 'faq'}}">
-                   <i class="fa-li fa fa-question" aria-hidden="true"></i>{{_ "faq"}}
+                   <i class="fa fa-question fa-fw" aria-hidden="true"></i>{{_ "faq"}}
                  </a></li>
                  <li role="separator" class="divider"></li>
                  <li><a href="https://opencollective.com/codebuddies" target="_blank">
-                   <i class="fa-li fa fa-globe" aria-hidden="true"></i>Open Collective
+                   <i class="fa fa-globe fa-fw" aria-hidden="true"></i>Open Collective
                  </a></li>
                </ul>
             </li>
-            <!--
-            <li><a href="{{pathFor 'about'}}">{{_ "about"}} <span class="sr-only">(current)</span></a></li>
-            <li><a href="{{pathFor 'faq'}}">{{_ "faq"}}</a></li>
-            -->
             <!-- Hangouts -->
             <li><a href="{{pathFor 'hangouts'}}">{{_ "browse_hangouts"}} <span class="sr-only">(current)</span></a></li>
             <!-- Study Groups -->

--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -18,8 +18,40 @@
 
           {{! for visitors only}}
           {{#unless currentUser}}
+            <li class="dropdown">
+               <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Community<span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu fa-ul">
+                 <li><a href="{{pathFor 'about'}}"><i class="fa-li fa fa-users" aria-hidden="true"></i>
+                   {{_ "about"}}<span class="sr-only">(current)</span>
+                 </a></li>
+                 <li role="separator" class="divider"></li>
+                 <li><a href="https://codebuddies.slack.com" target="_blank">
+                      <i class="fa-li fa fa-slack" aria-hidden="true"></i>Slack
+                    </a></li>
+                 <li role="separator" class="divider"></li>
+                 <li><a href="https://github.com/codebuddiesdotorg/codebuddies" target="_blank">
+                   <i class="fa-li fa fa-github" aria-hidden="true"></i>Github
+                 </a></li>
+                 <li role="separator" class="divider"></li>
+                 <li><a href="https://medium.com/codebuddies" target="_blank">
+                   <i class="fa-li fa fa-medium" aria-hidden="true"></i>Blog
+                 </a></li>
+                 <li role="separator" class="divider"></li>
+                 <li><a href="{{pathFor 'faq'}}">
+                   <i class="fa-li fa fa-question" aria-hidden="true"></i>{{_ "faq"}}
+                 </a></li>
+                 <li role="separator" class="divider"></li>
+                 <li><a href="https://opencollective.com/codebuddies" target="_blank">
+                   <i class="fa-li fa fa-globe" aria-hidden="true"></i>Open Collective
+                 </a></li>
+               </ul>
+            </li>
+            <!--
             <li><a href="{{pathFor 'about'}}">{{_ "about"}} <span class="sr-only">(current)</span></a></li>
             <li><a href="{{pathFor 'faq'}}">{{_ "faq"}}</a></li>
+            -->
             <!-- Hangouts -->
             <li><a href="{{pathFor 'hangouts'}}">{{_ "browse_hangouts"}} <span class="sr-only">(current)</span></a></li>
             <!-- Study Groups -->

--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -16,53 +16,50 @@
       <div class="collapse navbar-collapse" id="cb2-navbar-collapse">
         <ul class="nav navbar-nav navbar-right">
 
+          <li class="dropdown">
+             <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Community<span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu fa-ul">
+               <li><a href="{{pathFor 'about'}}"><i class="fa fa-users fa-fw" aria-hidden="true"></i>
+                 {{_ "about"}}<span class="sr-only">(current)</span>
+               </a></li>
+               <li role="separator" class="divider"></li>
+               <li><a href="https://codebuddies.slack.com" target="_blank">
+                    <i class="fa fa-slack fa-fw" aria-hidden="true"></i>Slack
+                  </a></li>
+               <li role="separator" class="divider"></li>
+               <li><a href="https://github.com/codebuddiesdotorg/codebuddies" target="_blank">
+                 <i class="fa fa-github fa-fw" aria-hidden="true"></i>Github
+               </a></li>
+               <li role="separator" class="divider"></li>
+               <li><a href="https://medium.com/codebuddies" target="_blank">
+                 <i class="fa fa-medium fa-fw" aria-hidden="true"></i>Blog
+               </a></li>
+               <li role="separator" class="divider"></li>
+               <li><a href="{{pathFor 'faq'}}">
+                 <i class="fa fa-question fa-fw" aria-hidden="true"></i>{{_ "faq"}}
+               </a></li>
+               <li role="separator" class="divider"></li>
+               <li><a href="https://opencollective.com/codebuddies" target="_blank">
+                 <i class="fa fa-globe fa-fw" aria-hidden="true"></i>Open Collective
+               </a></li>
+             </ul>
+          </li>
+          <!-- Hangouts -->
+          <li><a href="{{pathFor 'hangouts'}}">{{_ "browse_hangouts"}} <span class="sr-only">(current)</span></a></li>
+          <!-- Study Groups -->
+          <li><a href="{{pathFor 'all study groups'}}">Study Groups</a></li>
+
           {{! for visitors only}}
           {{#unless currentUser}}
-            <li class="dropdown">
-               <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Community<span class="caret"></span>
-              </a>
-              <ul class="dropdown-menu fa-ul">
-                 <li><a href="{{pathFor 'about'}}"><i class="fa fa-users fa-fw" aria-hidden="true"></i>
-                   {{_ "about"}}<span class="sr-only">(current)</span>
-                 </a></li>
-                 <li role="separator" class="divider"></li>
-                 <li><a href="https://codebuddies.slack.com" target="_blank">
-                      <i class="fa fa-slack fa-fw" aria-hidden="true"></i>Slack
-                    </a></li>
-                 <li role="separator" class="divider"></li>
-                 <li><a href="https://github.com/codebuddiesdotorg/codebuddies" target="_blank">
-                   <i class="fa fa-github fa-fw" aria-hidden="true"></i>Github
-                 </a></li>
-                 <li role="separator" class="divider"></li>
-                 <li><a href="https://medium.com/codebuddies" target="_blank">
-                   <i class="fa fa-medium fa-fw" aria-hidden="true"></i>Blog
-                 </a></li>
-                 <li role="separator" class="divider"></li>
-                 <li><a href="{{pathFor 'faq'}}">
-                   <i class="fa fa-question fa-fw" aria-hidden="true"></i>{{_ "faq"}}
-                 </a></li>
-                 <li role="separator" class="divider"></li>
-                 <li><a href="https://opencollective.com/codebuddies" target="_blank">
-                   <i class="fa fa-globe fa-fw" aria-hidden="true"></i>Open Collective
-                 </a></li>
-               </ul>
-            </li>
-            <!-- Hangouts -->
-            <li><a href="{{pathFor 'hangouts'}}">{{_ "browse_hangouts"}} <span class="sr-only">(current)</span></a></li>
-            <!-- Study Groups -->
-            <li><a href="{{pathFor 'all study groups'}}">Study Groups</a></li>
 
             <li><a href="#" class="signIn"><button class="btn btn-slack"><img src="/images/slack-icon.png">&nbsp;&nbsp;{{_ "sign_in_with"}} <b>Slack</b></button></a></li>
 
           {{! for logged in user}}
           {{else}}
-            <!-- Hangouts -->
-            <li><a href="{{pathFor 'hangouts'}}">{{_ "browse_hangouts"}} <span class="sr-only">(current)</span></a></li>
-            <!-- Study Groups -->
-            <li><a href="{{pathFor 'all study groups'}}">Study Groups</a></li>
 
-            {{! won't be visible to cb admin}}
+            {{! won''t be visible to cb admin}}
             {{#unless isInRole 'admin' 'CB'}}
               <!-- notification for user-->
               <li><a href="{{pathFor 'user notification'}}"><i class="fa fa-bell" aria-hidden="true"></i> {{#if userNotificationCount}}<small><span class="badge">{{userNotificationCount}}</span></small>{{/if}} </a></li>
@@ -86,8 +83,6 @@
                   <ul class="dropdown-menu" role="menu">
                     <li><a href="{{pathFor 'my study groups'}}"><i class="fa fa-users fa-fw"></i> {{_ "my_study_groups"}}</a></li>
                     <li><a href="/profile/{{user.username}}/{{user._id}}"><i class="fa fa-user fa-fw"></i> {{_ "profile"}}</a></li>
-                    <li><a href="http://github.com/codebuddiesdotorg/codebuddies"><i class="fa fa-github fa-fw"></i> Github</a></li>
-                    <li><a href="https://codebuddies.slack.com/messages/general" target="_blank"><i class="fa fa-slack fa-fw" aria-hidden="true"></i> Slack</a></li>
                     <li><a href="{{pathFor 'account' name=user.username userId=user._id}}"><i class="fa fa-gear fa-fw"></i> {{_ "settings"}}</a></li>
                     <li><a href="#" id="signOut"><i class="fa fa-sign-out fa-fw"></i> {{_ "sign_out"}}</a></li>
                   </ul>


### PR DESCRIPTION
Fixes #654 

Group About and FAQ in Community dropdown menu.
The dropdown menu is consisted of github, slack, blog and open collaborative menu items.
Each menu item has a font-awesome with a menu text to its right
![navbar](https://user-images.githubusercontent.com/1159649/31572616-ed8d4f8c-b0dc-11e7-8276-e688864e2709.png)
