### PR TITLE
Issue 652 member status timesamp

### DIFF
--- a/client/templates/admin/notification/all_notifications.js
+++ b/client/templates/admin/notification/all_notifications.js
@@ -1,9 +1,14 @@
 Template.registerHelper('dispDate', function(date) {
+  console.log('date', date);
   return moment(date).format('h:mm a \ Do MMM \'YY');
 });
 
 Template.registerHelper("isActorAdmin", function(actorId){
   return Roles.userIsInRole( actorId, ['admin'], 'CB') ;
+});
+
+Template.registerHelper('dispCustomDate', function(date, format) {
+  return moment(date).format(format);
 });
 
 Template.allNotification.onCreated(function() {

--- a/client/templates/admin/notification/all_notifications.js
+++ b/client/templates/admin/notification/all_notifications.js
@@ -1,5 +1,4 @@
 Template.registerHelper('dispDate', function(date) {
-  console.log('date', date);
   return moment(date).format('h:mm a \ Do MMM \'YY');
 });
 

--- a/client/templates/study_groups/study_group_members.html
+++ b/client/templates/study_groups/study_group_members.html
@@ -46,6 +46,9 @@
            </td>
            <td>
              <span>{{status}}</span>
+             {{#if status_modifiedAt }}
+              <small> &nbsp; {{dispCustomDate status_modifiedAt 'dddd, MMM DD, YYYY h:mm a'}} </small>
+             {{/if}}
            </td>
            <td>
              <a class="memberDetail btn btn-default pull-right">Modify</a>
@@ -79,6 +82,9 @@
          </td>
          <td>
            <span>{{status}}</span>
+           {{#if status_modifiedAt }}
+            <small> &nbsp; {{dispCustomDate status_modifiedAt 'dddd, MMM DD, YYYY h:mm a'}} </small>
+           {{/if}}
          </td>
        </tr>
       {{/each}}


### PR DESCRIPTION
Fixes #652.
 
Display member status timestamp in  current status column of member table in Members tab.
Format of the timestamp is Sunday, Oct 15, 2017 4:26 pm





![memberstatustimestamp](https://user-images.githubusercontent.com/1159649/31583087-a63c7456-b1c6-11e7-8393-c663779e7b77.png)

