### PR TITLE
Issue 668 study group announcement

### DIFF
--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -143,7 +143,7 @@ studyGroupNotification = function(studyGroup, studyGroupId) {
 
   const username = studyGroup.members[0].name;
   const studyGroupUrl = Meteor.absoluteUrl(`study-group/${studyGroup.slug}/${studyGroupId}`);
-  const pretext = `@${username} has started a *${studyGroup.title}* study group with the tagline *${studyGroup.tagline}*.\nJoin here: ${studyGroupUrl} `;
+  const pretext = `<@${username}> has started a *${studyGroup.title}* study group with the tagline *${studyGroup.tagline}*.\nJoin here: ${studyGroupUrl} `;
 
   console.log(pretext);
   studyGroupAlert({

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -132,3 +132,16 @@ slackNotification = function(hangout, type){
   hangoutAlert(data)
   }
 }//slackNotification();
+
+studyGroupNotification = function(studyGroup, studyGroupId) {
+
+  const username = studyGroup.members[0].name;
+  const studyGroupUrl = Meteor.absoluteUrl(`study-group/${studyGroup.slug}/${studyGroupId}`);
+  const pretext = `@${username} has started a *${studyGroup.title}* study group with the tagline ${studyGroup.tagline}.\nJoin here: ${studyGroupUrl} `;
+
+  console.log(pretext);
+  const data = {
+      text: pretext
+  };
+  hangoutAlert(data);
+}

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -24,7 +24,7 @@ slackNotification = function(hangout, type){
   if (attendees_list.length ==1) {
     nameString += '<@' + attendees_list[0]['name'] + '> has RSVPed!';
   } else if (attendees_list.length == 2) {
-    nameString = '<@' + attendees_list[0]['name'] + '> and <@' + attendees_list[1]['name'] + '> have RSVPed!'; 
+    nameString = '<@' + attendees_list[0]['name'] + '> and <@' + attendees_list[1]['name'] + '> have RSVPed!';
   } else {
     attendees_list.forEach(function(element) {
       if (element!==attendees_list[attendees_List.length-1]){
@@ -133,15 +133,20 @@ slackNotification = function(hangout, type){
   }
 }//slackNotification();
 
+studyGroupAlert = slack.extend({
+    channel: Meteor.settings.slack_alert_channel,
+    icon_emoji: ':notebook:',
+    username: Meteor.settings.slack_studygroup_alert_username
+});
+
 studyGroupNotification = function(studyGroup, studyGroupId) {
 
   const username = studyGroup.members[0].name;
   const studyGroupUrl = Meteor.absoluteUrl(`study-group/${studyGroup.slug}/${studyGroupId}`);
-  const pretext = `@${username} has started a *${studyGroup.title}* study group with the tagline ${studyGroup.tagline}.\nJoin here: ${studyGroupUrl} `;
+  const pretext = `@${username} has started a *${studyGroup.title}* study group with the tagline *${studyGroup.tagline}*.\nJoin here: ${studyGroupUrl} `;
 
   console.log(pretext);
-  const data = {
-      text: pretext
-  };
-  hangoutAlert(data);
+  studyGroupAlert({
+    text: pretext
+  });
 }

--- a/server/slack/methods.js
+++ b/server/slack/methods.js
@@ -143,7 +143,7 @@ studyGroupNotification = function(studyGroup, studyGroupId) {
 
   const username = studyGroup.members[0].name;
   const studyGroupUrl = Meteor.absoluteUrl(`study-group/${studyGroup.slug}/${studyGroupId}`);
-  const pretext = `<@${username}> has started a *${studyGroup.title}* study group with the tagline *${studyGroup.tagline}*.\nJoin here: ${studyGroupUrl} `;
+  const pretext = `<@${username}> has started a *${studyGroup.title}* study group with the tagline *${studyGroup.tagline}*!\nJoin here: ${studyGroupUrl} `;
 
   console.log(pretext);
   studyGroupAlert({

--- a/server/study_groups/methods.js
+++ b/server/study_groups/methods.js
@@ -81,6 +81,8 @@ Meteor.methods({
 
     Activities.insert(activity);
 
+    // send slack alert
+    studyGroupNotification(studyGroup, studyGroupId);
 
     return true;
 

--- a/settings-development.json
+++ b/settings-development.json
@@ -27,8 +27,9 @@
   "team_id":"T04AQ6GEY",
   "slack_alert_channel": "#codebuddies-ops",
   "slack_alert_username": "CodeBuddies Alerts",
-  "hangout_reminder_interval": "every 1 hour", 
+  "hangout_reminder_interval": "every 1 hour",
   "root_email":"codebuddiesdotorg@gmail.com",
   "root_username":"CB",
-  "root_gravatar":"http://www.gravatar.com/avatar/"
+  "root_gravatar":"http://www.gravatar.com/avatar/",
+  "slack_studygroup_alert_username": "Study Group Alerts"
 }


### PR DESCRIPTION
Fixes #668.

When study group is created, the method called studyGroupNotification() in slack/method.js to send simple text message to channel.
Study group notification uses notebook emoji and 'Study Group Alerts' username to display alert in the channel.
Username is defined as a property in setting-development.json; therefore, a corresponding entry should exist in production config in production hosting location. 