### PR TITLE
Show form error messages inside modal

### DIFF
--- a/client/templates/study_groups/edit_study_group_resources_modal.html
+++ b/client/templates/study_groups/edit_study_group_resources_modal.html
@@ -29,6 +29,12 @@
               {{else}}
                 <button type="button" class="btn btn-default btn-block disabled"><i class="fa fa-refresh fa-spin"></i> {{_ "state_processing"}}</button>
               {{/unless}}
+
+              {{#if alert}}
+                <div class="margin-top-1 align-center alert {{alert.type}}">
+                  <span>{{alert.message}}</span>
+                </div>
+              {{/if}}
             </div>
 
           </form>

--- a/client/templates/study_groups/edit_study_group_resources_modal.html
+++ b/client/templates/study_groups/edit_study_group_resources_modal.html
@@ -11,14 +11,20 @@
             <div class="modal-body">
 
 
-              <div class="form-group">
+              <div class="form-group {{#if isError 'sgResourceTitle'}}has-error{{/if}}">
                 <label  class="control-label">Title</label>
                 <input type="text" class="form-control" id="sgResourceTitle" placeholder="Title">
+                {{#if isError 'sgResourceTitle'}}
+                  <span class="help-block">{{alert.message}}</span>
+                {{/if}}
               </div>
 
-              <div class="form-group">
+              <div class="form-group {{#if isError 'sgResourceURL'}}has-error{{/if}}">
                 <label  class="control-label">URL</label>
                 <input type="text" class="form-control" id="sgResourceURL" placeholder="https://example.com/">
+                {{#if isError 'sgResourceURL'}}
+                  <span class="help-block">{{alert.message}}</span>
+                {{/if}}
               </div>
 
             </div><!--modal body-->
@@ -31,9 +37,11 @@
               {{/unless}}
 
               {{#if alert}}
+              {{#unless alert.elementId}}
                 <div class="margin-top-1 align-center alert {{alert.type}}">
                   <span>{{alert.message}}</span>
                 </div>
+              {{/unless}}
               {{/if}}
             </div>
 

--- a/client/templates/study_groups/edit_study_group_resources_modal.js
+++ b/client/templates/study_groups/edit_study_group_resources_modal.js
@@ -6,10 +6,13 @@ Template.editStudyGroupResourcesModal.onCreated(function () {
 
 Template.editStudyGroupResourcesModal.helpers({
   processing() {
-    return  Template.instance().processing.get();
+    return Template.instance().processing.get();
   },
   alert() {
     return Template.instance().alert.get();
+  },
+  isError(elementId) {
+    return Template.instance().alert.get().elementId === elementId;
   }
 });
 
@@ -21,11 +24,11 @@ Template.editStudyGroupResourcesModal.events({
 
     if ($.trim(template.find("#sgResourceTitle").value) == '') {
       $('#sgResourceTitle').css({ 'border': '#FF0000 1px solid'});
-      return template.alert.set( { type: "alert-warning", message: "Resource Title" } );
+      return template.alert.set({ type: "alert-warning", elementId:"sgResourceTitle", message: "Please include a link title." });
     }
     if ($.trim(template.find("#sgResourceURL").value) == '') {
       $('#sgResourceURL').css({ 'border': '#FF0000 1px solid'});
-      return template.alert.set( { type: "alert-warning", message: "Resource URL" } );
+      return template.alert.set({ type: "alert-warning", elementId:"sgResourceURL", message: "Please include a link URL." });
     }
 
     let data = {
@@ -38,7 +41,7 @@ Template.editStudyGroupResourcesModal.events({
 
     // console.log(data);
     template.processing.set( true );
-    template.alert.set ( false );
+    template.alert.set( false );
 
     Meteor.call("addResource", data, function(error, result){
       if(error){

--- a/client/templates/study_groups/edit_study_group_resources_modal.js
+++ b/client/templates/study_groups/edit_study_group_resources_modal.js
@@ -1,11 +1,15 @@
 Template.editStudyGroupResourcesModal.onCreated(function () {
   let instance = this;
   instance.processing = new ReactiveVar(false);
+  instance.alert = new ReactiveVar(false);
 });
 
 Template.editStudyGroupResourcesModal.helpers({
   processing() {
     return  Template.instance().processing.get();
+  },
+  alert() {
+    return Template.instance().alert.get();
   }
 });
 
@@ -17,11 +21,11 @@ Template.editStudyGroupResourcesModal.events({
 
     if ($.trim(template.find("#sgResourceTitle").value) == '') {
       $('#sgResourceTitle').css({ 'border': '#FF0000 1px solid'});
-      return Bert.alert( 'Resource Title', 'warning', 'growl-top-right' );
+      return template.alert.set( { type: "alert-warning", message: "Resource Title" } );
     }
     if ($.trim(template.find("#sgResourceURL").value) == '') {
       $('#sgResourceURL').css({ 'border': '#FF0000 1px solid'});
-      return Bert.alert( 'Resource URL', 'warning', 'growl-top-right' );
+      return template.alert.set( { type: "alert-warning", message: "Resource URL" } );
     }
 
     let data = {
@@ -34,11 +38,12 @@ Template.editStudyGroupResourcesModal.events({
 
     // console.log(data);
     template.processing.set( true );
+    template.alert.set ( false );
 
     Meteor.call("addResource", data, function(error, result){
       if(error){
         template.processing.set( false );
-        Bert.alert( error.reason, 'danger', 'growl-top-right' );
+        template.alert.set( { type: "alert-danger", message: error.reason } );
       }
       if(result){
         template.processing.set( false );


### PR DESCRIPTION
Fixes #568.

I couldn't use the current alert implementation with `Bert.alert()`. Bert attaches the alert on a different level than the modal resides. I couldn't come up with any solution to easily 'move it' inside the modal. Instead, I created a simple alert object in the template and used Bootstrap (which is already being used in the project) to style it. Let me know what you think of this implementation.

EDIT: added a screenshot.
![localhost-3000-study-group-test-group-rv9ngbfowlmmj7mbj](https://user-images.githubusercontent.com/9724469/31852227-6e752150-b674-11e7-8c59-5fc0b9dc5bfe.png)