### PR TITLE
Chore/issue 655 fix edit button hover state

### DIFF
--- a/client/css/_buttons.scss
+++ b/client/css/_buttons.scss
@@ -53,9 +53,13 @@
   margin-right: 35px;
   padding: 6px 12px;
   text-decoration: none;
-  i { margin-right: 8px; }
-  &:hover { background: $white; color: $cta-blue;}
-  &.editProfile { color: $white }
+
+  > .fa { margin-right: 8px; }
+
+  &:hover {
+    background: $white;
+    color: $cta-blue;
+  }
 }
 
 .btn-circle {

--- a/client/css/_buttons.scss
+++ b/client/css/_buttons.scss
@@ -44,17 +44,15 @@
 }
 
 .btn-edit {
+  display: inline-block;
+  margin-top: 15px;
+  padding: 6px 12px;
   border: 1px solid $divider;
   border-radius: 4px;
   color: $bg-white;
-  float: right;
   font-family: $open-sans;
   font-size: 13px;
-  margin-right: 35px;
-  padding: 6px 12px;
   text-decoration: none;
-
-  > .fa { margin-right: 8px; }
 
   &:hover {
     background: $white;

--- a/client/css/_fonts.scss
+++ b/client/css/_fonts.scss
@@ -3,36 +3,41 @@
 
 $open-sans: 'Open Sans', sans-serif;
 
-.fa-microphone-slash { color: $icon-silent;}
-.fa-user { color: $icon-teaching;}
-.fa-users { color: $icon-collab;}
+.fa-microphone-slash { color: $icon-silent; }
+.fa-user { color: $icon-teaching; }
+.fa-users { color: $icon-collab; }
 
+a { color: $dodgerblue; }
 
-a:link:not(.btn-cb2), a:visited:not(.btn-cb2) {
-	color: $dodgerblue;
+h4.hangout-date,
+h5.in-progress,
+h5.upcoming,
+h5.completed {
+  display: inline;
+  font-size: 12px;
+  letter-spacing: 0.1px;
+  color: $warm-grey;
+  text-transform: uppercase;
+  font-weight: 500;
 }
-h4.hangout-date, h5.in-progress, h5.upcoming, h5.completed {
-    display: inline;
-    font-size: 12px;
-    letter-spacing: 0.1px;
-    color: $warm-grey;
-    text-transform: uppercase;
-    font-weight: 500;
-}
-h5.in-progress, h5.upcoming {
+
+h5.in-progress,
+h5.upcoming {
     color: $primary-grey;
 }
+
 .oval {
+	@include border-radius(5px);
 	width: 10px;
 	height: 10px;
 	background-color: $danger-red;
-	@include border-radius(5px);
 	display: inline-block;
 }
 
-  span.cb-delete:hover {
-    cursor: pointer;
-  }
+span.cb-delete:hover {
+  cursor: pointer;
+}
+
 .search-message {
     font-weight: 200;
 }

--- a/client/css/_profile.scss
+++ b/client/css/_profile.scss
@@ -49,6 +49,12 @@
   color: $bg-white;
   letter-spacing: .2px;
 
+  .profile-avatar {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
   .username {
     margin-top: 15px;
     margin-bottom: 15px;

--- a/client/templates/profile/profile.html
+++ b/client/templates/profile/profile.html
@@ -8,17 +8,24 @@
             {{> profileEdit}}
           {{/with}}
         {{else}}
-          {{#if isCurrentUserProfile currentUser}}
-            <a href="#profileEdit" class="btn-edit editProfile"><i class="fa fa-pencil" aria-hidden="true"></i>{{_ "Edit"}}</a>
-          {{/if}}
-          <div class="col-md-4 col-md-offset-4 text-center">
+          <div class="col-sm-12 text-center">
             {{#with userInfo}}
-              <img src="{{#if profile.avatar.image_192 }} {{profile.avatar.image_192}} {{else}} {{profile.avatar.default}} {{/if}}" class="img-circle avatar" alt="profile image"/>
-              <h3 class="username">{{username}}
+              <img src="{{#if profile.avatar.image_192 }} {{profile.avatar.image_192}} {{else}} {{profile.avatar.default}} {{/if}}" class="img-circle avatar profile-avatar" alt="profile image"/>
+
+              {{#if isCurrentUserProfile currentUser}}
+                <a href="#profileEdit" class="btn-edit editProfile">
+                  <i class="fa fa-pencil" aria-hidden="true"></i>
+                  {{_ "Edit Profile"}}
+                </a>
+              {{/if}}
+
+              <h3 class="username">
                 {{#if status.online}}
                   <i class="fa fa-circle online-now" aria-hidden="true"></i>
                 {{/if}}
+                {{username}}
               </h3>
+
               <p class="bio">{{profile.bio}}</p>
               <div class="social-icons">
                 {{# if userInfo.username }}
@@ -26,6 +33,7 @@
                     <i class="fa fa-slack" aria-hidden="true"></i>
                   </a>
                 {{/if}}
+
                 {{# if profile.social.twitter}}
                   <a href="https://twitter.com/{{profile.social.twitter}}" target="_blank">
                     <i class="fa fa-twitter" aria-hidden="true"></i>


### PR DESCRIPTION
Fixes #655.

Fixes hover state of `.editProfile` button in the Profile sections by restructuring how we style links. Refactor link styles to scope all anchor tags vs scoping anchors that are not classed with `.btn-cb2`.

Minor clean up of the Profile section by moving the edit button under the avatar. This cleans up an issue with the .editProfile button rendering under the column of the profile section, making it non-clickable when the browser window is too short.

![image](https://user-images.githubusercontent.com/3891869/31857265-98b0c626-b68e-11e7-92c4-c4f21f22c478.png)

On Hover:
![image](https://user-images.githubusercontent.com/3891869/31857283-6072c948-b68f-11e7-8c7b-9f2bf6ff20d5.png)
