### PR TITLE
Changed color of "Click to load hangout" issue#697

### DIFF
--- a/client/css/_colors.scss
+++ b/client/css/_colors.scss
@@ -37,3 +37,7 @@ $well: #f5f5f5;
 .text-success-color {
   color: $hangout-collab;
 }
+
+.load-hangout{
+  color: $success-green;
+}


### PR DESCRIPTION
Solved Issue #697
Made the "Click to load hangout" text green.

Fixes #\<issue number\>.

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue above.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.

Always follow the [contribution guidelines](https://github.com/codebuddiesdotorg/codebuddies/blob/master/contributing.md) when submitting a pull request.
