### PR TITLE
Issue 718 external link icons

### DIFF
--- a/client/templates/nav/header.html
+++ b/client/templates/nav/header.html
@@ -27,18 +27,22 @@
                <li role="separator" class="divider"></li>
                <li><a href="https://codebuddies.slack.com" target="_blank">
                     <i class="fa fa-slack fa-fw" aria-hidden="true"></i>Slack
+                    <i class="fa fa-external-link fa-fw" aria-hidden="true"></i>
                   </a></li>
                <li role="separator" class="divider"></li>
                <li><a href="https://github.com/codebuddiesdotorg/codebuddies" target="_blank">
                  <i class="fa fa-github fa-fw" aria-hidden="true"></i>Github
+                 <i class="fa fa-external-link fa-fw" aria-hidden="true"></i>
                </a></li>
                <li role="separator" class="divider"></li>
                <li><a href="https://www.facebook.com/groups/TOPSTUDYGROUP/" target="_blank">
                  <i class="fa fa-facebook fa-fw" aria-hidden="true"></i>Facebook Group
+                 <i class="fa fa-external-link fa-fw" aria-hidden="true"></i>
                </a></li>
                <li role="separator" class="divider"></li>
                <li><a href="https://medium.com/codebuddies" target="_blank">
                  <i class="fa fa-medium fa-fw" aria-hidden="true"></i>Blog
+                 <i class="fa fa-external-link fa-fw" aria-hidden="true"></i>
                </a></li>
                <li role="separator" class="divider"></li>
                <li><a href="{{pathFor 'faq'}}">
@@ -51,7 +55,7 @@
           <!-- Study Groups -->
           <li><a href="{{pathFor 'all study groups'}}">Study Groups</a></li>
           <!-- Donate -->
-          <li><a href="https://opencollective.com/codebuddies" target="_blank">Sponsor Us</a></li>
+          <li><a href="https://opencollective.com/codebuddies" target="_blank">Sponsor Us <i class="fa fa-external-link fa-fw" aria-hidden="true"></i></a></li>
           {{! for visitors only}}
           {{#unless currentUser}}
 


### PR DESCRIPTION
Fixes #718 

Use external-link icon in menu items of Community menu and Sponsor Us link

![external-link-icons](https://user-images.githubusercontent.com/1159649/32990969-9ec52746-cd6d-11e7-98a1-47719a9d9946.png)
