### PR TITLE
Issue 446 Adds language detection for TAPi18n

### DIFF
--- a/client/templates/main.js
+++ b/client/templates/main.js
@@ -9,6 +9,12 @@ if (Meteor.isClient) {
       console = console || {};
       console.log = function(){};
     }
+
+    const defaultLang = 'en'
+    const urlLang = FlowRouter.getQueryParam('lang')
+    const browserLang = (window.navigator.userLanguage || window.navigator.language || '').slice(0,2)
+    TAPi18n.setLanguage(urlLang || browserLang || defaultLang)
+
   });
 }
 


### PR DESCRIPTION
Fixes #446.

Took inspiration from https://themeteorchef.com/tutorials/i18n-and-meteor#tmc-auto-setting.

Default language fall back is 'en'.
Language can forced using the query param `lang`.

