### PR TITLE
Language switching and local storage persistence

### DIFF
--- a/client/css/_footer.scss
+++ b/client/css/_footer.scss
@@ -37,16 +37,25 @@
   }
 
 // column 2
+  .footer-languages {
+    @include breakpoint(tiny) { margin: 20px 0; }
+    @include breakpoint(xsmall) { margin: 20px 0; }
+    @include breakpoint(small) { margin: 0 0 20px; }
+    @include breakpoint(xmedium) { margin: 0 0 20px; }
+    a {padding-bottom: 10px; }
+    a.selected_language {font-weight: bold}
+  }
+
+// column 3
   .footer-links {
     @include breakpoint(tiny) { margin: 20px 0; }
     @include breakpoint(xsmall) { margin: 20px 0; }
     @include breakpoint(small) { margin: 0 0 20px; }
     @include breakpoint(xmedium) { margin: 0 0 20px; }
     a {padding-bottom: 10px; }
-
   }
 
-// column 3
+// column 4
   .footer-social {
 
     a {display: inline-block;}
@@ -86,7 +95,7 @@
   a:hover {
     color: #333;
   }
-  
+
 // media queries
   @include breakpoint(tiny) {
     padding: 0;

--- a/client/templates/home/footer.html
+++ b/client/templates/home/footer.html
@@ -4,12 +4,20 @@
       <div class="container">
 
         <div class="row">
-          <div class="col-md-6"> <!-- column 1 -->
+          <div class="col-md-4"> <!-- column 1 -->
             <div class="footer-logo">
               <p href="{{pathFor 'home'}}"><img src="/images/logo.svg"></p>
             </div>
           </div>
           <div class="col-md-2"> <!-- column 2 -->
+            <div class="footer-languages">
+              <p><strong>LANGUAGE</strong></p>
+              {{#each languageSwitcher in languageSwitchers}}
+                  <a href="#" {{languageSwitcher.attributes}}>{{languageSwitcher.name}}</a>
+              {{/each}}
+            </div>
+          </div>
+          <div class="col-md-2"> <!-- column 3 -->
             <div class="footer-links">
               <p><strong>COMMUNITY</strong></p>
                 <a href="/about">About Us</a>
@@ -21,7 +29,7 @@
                 <a href="https://opencollective.com/codebuddies" target="_blank">Open Collective</a>
             </div>
           </div>
-          <div class="col-md-2"> <!-- column 3 -->
+          <div class="col-md-2"> <!-- column 4 -->
             <div class="footer-social">
               <p><strong>CONNECT WITH US</strong></p>
               <span class="footer-icons">
@@ -32,7 +40,7 @@
               </span>
             </div>
           </div>
-          <div class="col-md-2"> <!-- column 4 -->
+          <div class="col-md-2"> <!-- column 5 -->
             <div class="footer-sponsor">
               <p><strong>SPONSOR US</strong></p>
               <p>Our project is free and <strong><a href="https://github.com/codebuddiesdotorg/codebuddies" target="_blank">open-sourced</a></strong>. Help keep this project alive by <a class="sponsor" href="http://opencollective.com/codebuddies" target="_blank"><strong>donating to our Open Collective</strong>.</a></p>
@@ -40,8 +48,7 @@
               <a href="/privacy">Privacy Policy</a>
             </div>
           </div>
-        </div> <!-- ends row -->
-    </div>
+    </div> <!-- ends row -->
   </div>
-
+</div>
 </template>

--- a/client/templates/home/footer.js
+++ b/client/templates/home/footer.js
@@ -19,6 +19,8 @@ Template.footer.events({
     event.preventDefault();
     const languageCode = event.target.dataset.langCode
     const languageName = event.target.dataset.langName
+    if (languageCode === TAPi18n.getLanguage())
+      return;
 
     TAPi18n.setLanguage(languageCode)
     .done(() => {

--- a/client/templates/home/footer.js
+++ b/client/templates/home/footer.js
@@ -29,7 +29,7 @@ Template.footer.events({
       console.log(error);
     })
     .always(() => {
-      localStorage.setItem('lang', TAPi18n.getLanguage());
+      localStorage.setItem('languageCode', TAPi18n.getLanguage());
     })
   }
 });

--- a/client/templates/home/footer.js
+++ b/client/templates/home/footer.js
@@ -1,0 +1,35 @@
+Template.footer.helpers({
+  languageSwitchers: function() {
+    const supportedLanguages = TAPi18n.getLanguages();
+    const currentLanguageCode = TAPi18n.getLanguage();
+    return Object.keys(supportedLanguages).map(function(languageCode){ return {
+      name: supportedLanguages[languageCode].name,
+      attributes: {
+        'data-lang':'',
+        'data-lang-code': languageCode,
+        'data-lang-name': supportedLanguages[languageCode].name,
+        'class': (languageCode === currentLanguageCode ? 'selected_language' : '')
+      }};
+    });
+  }
+});
+
+Template.footer.events({
+  "click [data-lang]": function(event, template){
+    event.preventDefault();
+    const languageCode = event.target.dataset.langCode
+    const languageName = event.target.dataset.langName
+
+    TAPi18n.setLanguage(languageCode)
+    .done(() => {
+      Bert.alert(TAPi18n.__("alert_language_change", `${languageName} (${languageCode})`), 'success', 'growl-top-right' );
+    })
+    .fail((error) => {
+      Bert.alert(TAPi18n.__("alert_language_change_fail", `${languageName} (${languageCode})`), 'danger', 'growl-top-right' );
+      console.log(error);
+    })
+    .always(() => {
+      localStorage.setItem('lang', TAPi18n.getLanguage());
+    })
+  }
+});

--- a/client/templates/main.js
+++ b/client/templates/main.js
@@ -9,11 +9,11 @@ if (Meteor.isClient) {
     }
 
     const defaultLang = 'en'
-    const localStorageLang = localStorage.getItem('lang');
+    const localStorageLang = localStorage.getItem('languageCode');
     const browserLang = (window.navigator.userLanguage || window.navigator.language || '').slice(0,2)
     TAPi18n.setLanguage(localStorageLang || browserLang || defaultLang)
     .fail(console.log)
-    .always(() => localStorage.setItem('lang', TAPi18n.getLanguage()))
+    .always(() => localStorage.setItem('languageCode', TAPi18n.getLanguage()))
   });
 }
 

--- a/client/templates/main.js
+++ b/client/templates/main.js
@@ -9,13 +9,13 @@ if (Meteor.isClient) {
     }
 
     const defaultLang = 'en'
-    const urlLang = FlowRouter.getQueryParam('lang')
+    const localStorageLang = localStorage.getItem('lang');
     const browserLang = (window.navigator.userLanguage || window.navigator.language || '').slice(0,2)
-    TAPi18n.setLanguage(urlLang || browserLang || defaultLang)
-
+    TAPi18n.setLanguage(localStorageLang || browserLang || defaultLang)
+    .fail(console.log)
+    .always(() => localStorage.setItem('lang', TAPi18n.getLanguage()))
   });
 }
-
 
 Template.registerHelper('equals', function (a, b) {
       return a === b;

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -148,5 +148,9 @@
   "leave_study_group": "Leave this Group",
   "select_study_group": "Please select a group.",
   "settings": "Settings",
-  "start_new_group": "Start a New Group"
+  "start_new_group": "Start a New Group",
+
+  // alerts
+  "alert_language_change": "Language changed to %s",
+  "alert_language_change_fail": "Could not change language to %s"
 }

--- a/i18n/es.i18n.json
+++ b/i18n/es.i18n.json
@@ -144,5 +144,9 @@
   "leave_study_group": "Deja este Grupo de Estudios",
   "select_study_group": "Por favor selecciona un grupo.",
   "settings": "Settings",
-  "start_new_group": "Inicia un nuevo grupo"
+  "start_new_group": "Inicia un nuevo grupo",
+
+  // alerts
+  "alert_language_change": "Idioma cambiado a %s",
+  "alert_language_change_fail": "No se pudo cambiar el idioma a %s"
 }


### PR DESCRIPTION
Supplements #446, #730.
- Adds language switching to footer
![image](https://user-images.githubusercontent.com/2686067/33112735-b92729f2-cf22-11e7-9352-4a76a8f152b9.png)
- Language list is generated dynamically from `TAPi18n.getLanguages()`
- Persisted via LocalStorage
- Removes query param for forcing language


![image](https://user-images.githubusercontent.com/2686067/33112789-f65989d2-cf22-11e7-9e91-140c5be0bc27.png)
![image](https://user-images.githubusercontent.com/2686067/33112800-0579352a-cf23-11e7-9aac-22a14b421c5d.png)


